### PR TITLE
Exit build scripts on errors to no create incomplete docker images

### DIFF
--- a/overpass-api-httpd/build.sh
+++ b/overpass-api-httpd/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 wget https://dev.overpass-api.de/releases/osm-3s_latest.tar.gz
 gunzip <osm-3s_latest.tar.gz | tar x

--- a/overpass-api-httpd/build.sh
+++ b/overpass-api-httpd/build.sh
@@ -16,7 +16,7 @@ popd
 
 pushd overpass
 mkdir -p db
-strip bin/*
-strip cgi-bin/*
+strip bin/* || true
+strip cgi-bin/* || true
 popd
 

--- a/overpass-api-server/build.sh
+++ b/overpass-api-server/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 wget https://dev.overpass-api.de/releases/osm-3s_latest.tar.gz
 gunzip <osm-3s_latest.tar.gz | tar x

--- a/overpass-api-server/build.sh
+++ b/overpass-api-server/build.sh
@@ -16,7 +16,7 @@ popd
 
 pushd overpass
 mkdir -p db
-strip bin/*
-strip cgi-bin/*
+strip bin/* || true
+strip cgi-bin/* || true
 popd
 


### PR DESCRIPTION
Currently `docker build` successfully creates a docker image even if `make` in `build.sh` fails. The resulting Docker image is not useful, because it doesn't contain the compiled programs, but there is no obvious indication that there were problems. When starting the container it results in errors [like this][1].

It makes more sense to abort the build in such cases. The simplest way is to tell bash to exit the build script on errors with `set -e`. This way errors on `./configure`, `make` and all other steps are covered.

An exception are the calls to `strip`. These calls are given shell scripts in their command line arguments, resulting in an error exist status that can be ignored.

  [1]: https://github.com/drolbr/docker-overpass/issues/4#issue-2128154971